### PR TITLE
Metaquery refactor

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,15 +7,17 @@
     "@material-ui/icons": "^4.9.1",
     "axios": "^0.19.2",
     "codemirror": "^5.56.0",
-    "graphiql": "^1.0.3",
+    "graphiql": "^1.4.1",
     "graphql": "^15.3.0",
     "isomorphic-fetch": "^2.2.1",
     "jsonlint-mod": "^1.7.5",
     "jwt-decode": "^2.2.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
-    "react-scripts": "^3.4.1",
-    "roboto-fontface": "^0.10.0"
+    "react-scripts": "^4.0.1",
+    "roboto-fontface": "^0.10.0",
+    "graphql-language-service-interface": "2.8.2",
+    "graphql-language-service-parser": "1.9.0"
   },
   "devDependencies": {},
   "scripts": {

--- a/src/GraphiQLMetaFilters.js
+++ b/src/GraphiQLMetaFilters.js
@@ -8,7 +8,7 @@ import FormControlLabel from '@material-ui/core/FormControlLabel';
 import FormControl from '@material-ui/core/FormControl';
 import IconButton from '@material-ui/core/IconButton';
 import PlayArrowIcon from '@material-ui/icons/PlayArrow';
-import CloseIcon from '@material-ui/icons/Close';
+import { Close as CloseIcon, InfoOutlined as InfoIcon} from '@material-ui/icons';
 import CodeMirror from 'codemirror';
 import 'codemirror/lib/codemirror.css';
 import 'codemirror/mode/javascript/javascript';
@@ -360,6 +360,12 @@ export default function GraphiQLMetaFilters(props) {
               >
                 Close
               </Button>
+            </Grid>
+            <Grid item style={{padding: 0, marginTop: 8, marginLeft: 10}}>
+              <InfoIcon color='primary'/>
+            </Grid>
+            <Grid item style={{padding: 0, marginTop: 6, marginLeft: 3, whiteSpace:'nowrap'}} >
+              Filters the contents of "data".
             </Grid>
           </Grid>
         </div>

--- a/src/graphiql.js
+++ b/src/graphiql.js
@@ -76,16 +76,16 @@ export default function MyGraphiQL(props){
     }
     //set metaQuery parameters
     let metaQueryParams = {
-      queries:   graphQLParams,
       jq:        selectedFilterRef.current==='jq' ? filterValueRef.current: null,
       jsonPath:  selectedFilterRef.current==='JsonPath' ? filterValueRef.current: null,
     };
     let headers = getHeaders();
+    Object.assign(headers, metaQueryParams)
 
     return fetch(metaquery_url, {
       method: 'post',
       headers: headers,
-      body: JSON.stringify(metaQueryParams),
+      body: JSON.stringify(graphQLParams),
     }).then(response => response.json(), error => {
       console.error("Error:", error);
       return {errors: error.message};


### PR DESCRIPTION
## Summary

implements changes according to [graphql-server pull#63](https://github.com/Zendro-dev/graphql-server/pull/63).

## Changes
### metaquery
- add jq/jsonPath transformation strings to the header instead of body
- add a info text for the user to be aware that the jq/jsonPath filter only ever acts on "data".

### package
- to avoid a dependency issue where the application wouldn't compile added the following to `package.json`
```
    "graphql-language-service-interface": "2.8.2",
    "graphql-language-service-parser": "1.9.0"
```
- update `graphiql: ^1.0.3 -> ^1.4.1"
- update `react-scripts: ^3.4.1 -> ^4.0.1"