### PR TITLE
feat: add windows scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,10 @@
   "private": true,
   "scripts": {
     "dev": "next dev -p ${PORT:-7000}",
+    "dev:win": "next dev -p 7000",
     "build": "next build",
-    "start": "next start -p ${PORT:-7000}"
+    "start": "next start -p ${PORT:-7000}",
+    "start:win": "next start -p 7000"
   },
   "dependencies": {
     "@emotion/react": "^11.10.0",
@@ -14,7 +16,7 @@
     "codemirror": "^5.65.0",
     "graphiql": "^1.11.3",
     "graphql": "^15.8.0",
-    "graphql-ws":"^5.10.0",
+    "graphql-ws": "^5.10.0",
     "jsonlint-mod": "^1.7.6",
     "next": "^12.2.4",
     "next-auth": "^4.10.3",


### PR DESCRIPTION
## Summary

This PR adds scripts to startup the dev and production servers on windows. See https://github.com/Zendro-dev/zendro/pull/9

## Changes

- add `dev:win` and `start:win` scripts